### PR TITLE
Improves absolute path support in ES6 imports.

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -57,8 +57,12 @@ function getDependencyCommand(content, filePath, prefix) {
   const closureRequires = getClosureRequires(content);
 
   const es6Imports = getEs6Imports(content).map((depPath) => {
-    const depAbsPath = path.join(path.dirname(filePath), depPath);
-    return path.join(prefix, path.relative('', depAbsPath));
+    if (depPath[0] === '/') {
+      return path.join(prefix, depPath);
+    } else {
+      const depAbsPath = path.join(path.dirname(filePath), depPath);
+      return path.join(prefix, path.relative('', depAbsPath));
+    }
   });
 
   const requires = [].concat(...closureRequires, ...es6Imports);

--- a/parser.js
+++ b/parser.js
@@ -57,6 +57,7 @@ function getDependencyCommand(content, filePath, prefix) {
   const closureRequires = getClosureRequires(content);
 
   const es6Imports = getEs6Imports(content).map((depPath) => {
+    // Supports absolute paths
     if (depPath[0] === '/') {
       return path.join(prefix, depPath);
     } else {


### PR DESCRIPTION
Hey Greg,

I have tested absolute path with Closure compiler in prod mode and they work perfectly. So now we just need to modify the deps writer to make sure absolute path works. I already tested the debugging mode locally and it works well. 