### PR TITLE
The base Dir was being ommited, dot was used always as based path

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,18 +8,22 @@ const parser = require('./parser.js');
 const PLUGIN_NAME = 'gulp-closure-deps';
 
 const cache = {};
-let cwd, prefix, baseDir;
+let cwd, prefix;
 
-let extractDependency = function(filePath, contents) {
-  return parser.getDependencyCommand(contents, filePath, prefix);
-};
+let extractDependencyFactory = function(baseDir) {
+  return function(filePath, contents) {
+    return parser.getDependencyCommand(contents, filePath, prefix, baseDir);
+  };
+}
 
 module.exports = function(opt) {
   opt = opt || {};
   prefix = opt.prefix || '';
-  baseDir = opt.baseDir || '';
+  const baseDir = opt.baseDir || '';
   let fileName = opt.fileName || 'deps.js';
   let files = [];
+
+  const extractDependency = extractDependencyFactory(baseDir);
 
   function bufferContents(file) {
     if (file.isNull()) return;

--- a/parser.js
+++ b/parser.js
@@ -47,8 +47,9 @@ function getLoadFlags(content) {
   }
 }
 
-function getDependencyCommand(content, filePath, prefix) {
-  const baseRelativePath = path.join(prefix, path.relative('.', filePath));
+function getDependencyCommand(content, filePath, prefix, baseDir) {
+  baseDir = baseDir || '.';
+  const baseRelativePath = path.join(prefix, path.relative(baseDir, filePath));
   let provides = getProvides(content);
   if (!provides.length) {
     provides = [baseRelativePath];


### PR DESCRIPTION
In previous versions of your plugin, a baseDir option is provided to omit that particular directory when resolving the path for the dependencies, that functionality was broken since in the current version, the baseDir is not being used.

This PR takes that option into account again, defaulting to '.' when it is not provided.